### PR TITLE
Proxmox 7 support, CheckMK Agent installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Following settings are made:
 - Configure snapshot retention for `zfs-auto-snapshot` interactively
 - `zfs_arc_[min|max]` will be calculated by size sum of all zpools in 512 MB steps
 - Configure backup of `/etc` folder to new zfs dataset on `rpool/pveconf`
-- configure `vm.swappiness` interactively
+- Configure `vm.swappiness` interactively
+- Install checkmk Agent with optional encryption and registration
+- Added Support for Proxmox VE 7.0

--- a/proxmox-zfs-postinstall.sh
+++ b/proxmox-zfs-postinstall.sh
@@ -14,6 +14,8 @@ PVE_CONF_BACKUP_TARGET=rpool/pveconf
 # Define timer for your backup cronjob (default: every 15 minutes fron 3 through 59)
 PVE_CONF_BACKUP_CRON_TIMER="3,18,33,48 * * * *"
 
+# Get Debian version info
+source /etc/os-release
 
 ###### SYSTEM INFO AND INTERACTIVE CONFIGURATION SECTION ######
 
@@ -167,7 +169,7 @@ if [[ "$(uname -r)" == *"-pve" ]]; then
     echo "Deactivating pve-enterprise repository"
     mv /etc/apt/sources.list.d/pve-enterprise.list /etc/apt/sources.list.d/pve-enterprise.list.bak > /dev/null 2>&1
     echo "Activating pve-no-subscription repository"
-    echo "deb http://download.proxmox.com/debian/pve buster pve-no-subscription" > /etc/apt/sources.list.d/pve-no-subscription.list
+    echo "deb http://download.proxmox.com/debian/pve $VERSION_CODENAME pve-no-subscription" > /etc/apt/sources.list.d/pve-no-subscription.list
 fi
 echo "Getting latest package lists"
 apt update > /dev/null 2>&1

--- a/proxmox-zfs-postinstall.sh
+++ b/proxmox-zfs-postinstall.sh
@@ -215,7 +215,7 @@ echo $ZFS_ARC_MAX_BYTES > /sys/module/zfs/parameters/zfs_arc_max
 
 cat << EOF > /etc/modprobe.d/zfs.conf
 options zfs zfs_arc_min=$ZFS_ARC_MIN_BYTES
-options zfs zfs_arc_min=$ZFS_ARC_MAX_BYTES
+options zfs zfs_arc_max=$ZFS_ARC_MAX_BYTES
 EOF
 
 if [[ "$install_checkmk" == "y" ]]; then


### PR DESCRIPTION
- Reads os codename for creating repository urls (required for Proxmox 6 and 7 support)
- Added installation routine for checkmk agent (optional encryption and registration support)