### PR TITLE
Fixed kernel ignoring tunable zfs_arc_min and zfs_arc_max

### DIFF
--- a/proxmox-zfs-postinstall.sh
+++ b/proxmox-zfs-postinstall.sh
@@ -229,8 +229,8 @@ echo $ZFS_ARC_MIN_BYTES > /sys/module/zfs/parameters/zfs_arc_min
 echo $ZFS_ARC_MAX_BYTES > /sys/module/zfs/parameters/zfs_arc_max
 
 cat << EOF > /etc/modprobe.d/zfs.conf
-options zfs zfs_arc_min=$ZFS_ARC_MIN_BYTES
 options zfs zfs_arc_max=$ZFS_ARC_MAX_BYTES
+options zfs zfs_arc_min=$ZFS_ARC_MIN_BYTES
 EOF
 
 if [[ "$install_checkmk" == "y" ]]; then


### PR DESCRIPTION
If zfs_arc_min and zfs_arc_max module options defined in wrong order (min, max) the kernel ignores and fallback to 0.

```
[    3.993342] WARNING: ignoring tunable zfs_arc_min (using 0 instead)
[    3.993345] WARNING: ignoring tunable zfs_arc_min (using 0 instead)
```

max, min work as intended.

```
pve-manager/7.3-3/c3928077 (running kernel: 5.15.74-1-pve)
zfs-2.1.6-pve1
zfs-kmod-2.1.6-pve1
```
