### PR TITLE
Append script to create ZFS swap volume

### DIFF
--- a/proxmox-zfs-postinstall.sh
+++ b/proxmox-zfs-postinstall.sh
@@ -99,19 +99,19 @@ fi
 echo -e "######## Configure Swapfile ########\n"
 
 read -p "With the default PVE-root on ZFS installation, no swap is created. Do you want to create a swapfile/zfs swap volume dataset? (y/n)" swapfile_userinput_bool
-if [ $swapfile_userinput_bool -eq "y" ]; then
+if [ $swapfile_userinput_bool == "y" ]; then
     read -p "Name for the swap dataset? Leave empty to use default 'swap'" swapfile_userinput_name
-    if [ x$swapfile_userinput_name -eq "x" ]; then
-        swapfile_name = "swap";
+    if [ x$swapfile_userinput_name == "x" ]; then
+        swapfile_name="swap";
     else 
-        swapfile_name = $swapfile_userinput_name;
+        swapfile_name=$swapfile_userinput_name;
     fi
     read -p "Size for the swap volume in G, only numbers" swapfile_userinput_size
     if echo "$swapfile_userinput_size" | grep -qE '^[0-9]+$'; then
-        swapfile_size = $swapfile_userinput_size;
+        swapfile_size=$swapfile_userinput_size;
     else
         echo "No valid input detected, falling back to 20G Swap Size";
-        swapfile_size = "20";
+        swapfile_size="20";
     fi
 else
     echo "No swapfile will be created"

--- a/proxmox-zfs-postinstall.sh
+++ b/proxmox-zfs-postinstall.sh
@@ -238,7 +238,7 @@ for interval in "${!auto_snap_keep[@]}"; do
 done
 
 
-if [ $swapfile_userinput_bool -eq "y" ]; then
+if [ $swapfile_userinput_bool == "y" ]; then
     echo "Creating swapfile"
     zfs create -V ${swapfile_size}G -b $(getconf PAGESIZE) -o logbias=throughput -o sync=always -o primarycache=metadata -o com.sun:auto-snapshot=false rpool/$swapfile_name
     echo "Formatting swapfile"


### PR DESCRIPTION
When using the default PVE GUI Installer and selecting ZFS for the root fs, the installer will not create any swap. 

Since this script offers to configure swappiness, we might want to create some swap before. 

This PR will ask the user interactively how big the swap volume should be and how it shall be named. It then creates a zfs volume/dataset with the name and the given size (rounded to full blocks), formats it as swap, enables it immediately and adds it to fstab so swap will be loaded each time the server boots.

When creating the zfs volume, the option `com.sun:auto-snapshot=false` is set to prevent the swap volume being snapshotted by zfs-auto-snapshots, which is also being installed by this script.